### PR TITLE
feat: hide actions and adjust allocation styles

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -10,6 +10,11 @@
 
     .AppActions {
         justify-content: space-between;
+
+        &.HiddenActions {
+            display: none;
+            
+        }
     }
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,7 +29,8 @@ function App() {
     const [state, setState]  = useState<{
         wallet?: Wallet, 
         chain?: Chain,
-        allocationResponse?: AllocationResponse
+        allocationResponse?: AllocationResponse,
+        airdropClaimedSuccessfully?: boolean,
     }>({});
 
     const handleWalletConnected = (wallet: Wallet, chain: Chain) => {
@@ -53,6 +54,10 @@ function App() {
         steps[activeStep].completed = true;
         steps[activeStep].completedLabel = "Successfully";
         updateSteps(steps);
+        setState({
+            ...state,
+            airdropClaimedSuccessfully: true
+        })
     }
     
     const handleCheckAnotherWallet = () => {
@@ -88,7 +93,7 @@ function App() {
                             onCheckAnotherWallet={handleCheckAnotherWallet}/> }
                 </CardContent>
 
-                <CardActions className='AppActions'>
+                <CardActions className={`AppActions ${state.airdropClaimedSuccessfully ? 'HiddenActions' : ''}`}>
                     <Button startIcon={<ArrowBackIos />}
                         variant="outlined"
                         disabled={activeStep === 0}

--- a/frontend/src/components/CheckAllocation/CheckAllocation.scss
+++ b/frontend/src/components/CheckAllocation/CheckAllocation.scss
@@ -1,6 +1,6 @@
 .CheckAllocationWrapper {
     margin: 1em auto 1em auto;
-    max-width: 420px;
+    min-width: 420px;
     text-align: center;
 
     .AllocationBody,
@@ -14,15 +14,11 @@
         width: 60px;
     }
 
-    h4 { 
-        font-weight: normal;
-
-    }
 
     
     .AllocationError {
 
-        h3 {
+        h4 {
             display: flex;
             align-items: center;
             justify-content: center;
@@ -43,5 +39,9 @@
 
     button {
         margin-top: 1em;
+    }
+
+    @media only screen and (max-width: 500px) {
+        min-width: auto;
     }
 }

--- a/frontend/src/components/CheckAllocation/index.tsx
+++ b/frontend/src/components/CheckAllocation/index.tsx
@@ -77,10 +77,10 @@ export const CheckAllocation = (props: CheckAllocationType) => {
           {allocationResponse?.has_claimed ? (
             <>
               <DoneAllIcon className="AllocationIcon success" />
-              <h4>The corresponding airdrop of</h4>
-              <h3>{allocationResponse.allocation} LUNA</h3>
-              <h4>was already processed for address</h4>
-              <h3>{address}</h3>
+              <h5>The corresponding airdrop of</h5>
+              <h4>{allocationResponse.allocation} LUNA</h4>
+              <h5>was already processed for address</h5>
+              <h4>{address}</h4>
             </>
           ) : (
             <>
@@ -88,9 +88,10 @@ export const CheckAllocation = (props: CheckAllocationType) => {
                 !allocationResponse?.message && (
                   <>
                     <InfoOutlinedIcon className="AllocationIcon info" />
-                    <h4>There is</h4>
-                    <h3>{parseAllocationRow(allocationResponse)}</h3>
-                    <h4>to be claimed for {address}</h4>
+                    <h5>There is</h5>
+                    <h4>{parseAllocationRow(allocationResponse)}</h4>
+                    <h5>to be claimed for</h5>
+                    <h4>{address}</h4>
                     <Button
                       variant="contained"
                       fullWidth
@@ -104,10 +105,10 @@ export const CheckAllocation = (props: CheckAllocationType) => {
               {!allocationResponse?.allocation && !allocationResponse?.message && (
                 <>
                   <ErrorOutlineIcon className="AllocationIcon error" />
-                  <h4>There is no airdrop to be claimed for address</h4>
-                  <h3>{address}</h3>
-                  <h4>from chain</h4>
-                  <h3>{chain.name}</h3>
+                  <h5>There is no airdrop to be claimed for address</h5>
+                  <h4>{address}</h4>
+                  <h5>from chain</h5>
+                  <h4>{chain.name}</h4>
                 </>
               )}
             </>
@@ -115,8 +116,8 @@ export const CheckAllocation = (props: CheckAllocationType) => {
 
           {allocationResponse?.message && (
             <div className="AllocationError">
-              <h4>{allocationResponse.message}</h4>
-              <h3>
+              <h5>{allocationResponse.message}</h5>
+              <h4>
                 <a
                   href="https://discord.com/invite/sTmERSFnYW"
                   target="_blank"
@@ -125,7 +126,7 @@ export const CheckAllocation = (props: CheckAllocationType) => {
                   Check Terra 2 Discord for help
                 </a>
                 <div className="icon external-link"></div>
-              </h3>
+              </h4>
             </div>
           )}
         </div>
@@ -134,10 +135,10 @@ export const CheckAllocation = (props: CheckAllocationType) => {
           <Loader
             bottomElement={
               <>
-                <h4>Checking airdrop for address</h4>
-                <h5>{address}</h5>
-                <h4>from chain</h4>
-                <h3>{chain.name}</h3>
+                <h5>Checking airdrop for address</h5>
+                <h4>{address}</h4>
+                <h5>from chain</h5>
+                <h4>{chain.name}</h4>
               </>
             }
           />


### PR DESCRIPTION
This pull request include style changes:

- Hide back button when the user claimed the airdrop successfully:
![image](https://user-images.githubusercontent.com/49301655/182125274-b38f50b8-0e7e-4e46-88b6-cf0552185a1e.png)

- Adjust fonts on check allocation screen (new version on the left): 
![image](https://user-images.githubusercontent.com/49301655/182125680-40bd1570-d614-47e7-8ad5-ea8784e6df9b.png)

![image](https://user-images.githubusercontent.com/49301655/182125918-6d8e84f8-39ec-43ec-8630-d945ed573a7a.png)

- Adjust sizes from check allocation so the screen does not change width when it changes thru different states:
![Peek 2022-08-01 12-10](https://user-images.githubusercontent.com/49301655/182126432-2c7434ba-912d-48f5-b077-9d788267c929.gif)