### PR TITLE
fix: Tell the user when they have the wrong address selected in station.

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -26,8 +26,8 @@ getChainOptions().then((chainOptions) => {
         <React.StrictMode>
             <ThemeProvider theme={darkTheme}>
                 <SnackbarProvider
-                    autoHideDuration={2000}
-                    anchorOrigin={{ vertical: 'top', horizontal: 'right'}}>
+                    autoHideDuration={5000}
+                    anchorOrigin={{ vertical: 'top', horizontal: 'center'}}>
                     <MetaMaskProvider>
                         <WalletProvider {...chainOptions}>
                             <App />


### PR DESCRIPTION
During testing we found that if you created a new wallet in station, then left that wallet active you would get an account sequence mismatch error. 

Lets detect that error and tell the user to switch back to the og wallet.


![localhost_3000_](https://user-images.githubusercontent.com/142006/183499070-c0895769-4dcd-4941-9091-2cd7038fbf01.png)
 